### PR TITLE
github auth: use email as username if no github displayName defined

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,7 +27,7 @@ class App extends Component {
             variables: {
               user: {
                 id: user.uid,
-                username: user.displayName,
+                username: user.displayName || user.email,
               },
             },
           }).then(() => self.setState({ authenticated: true }));


### PR DESCRIPTION
because auth would fails (username mandatory in User in graphQL shema)